### PR TITLE
Fix API changes in qgrid and ipywidgets

### DIFF
--- a/pstatsviewer/viewer.py
+++ b/pstatsviewer/viewer.py
@@ -4,7 +4,7 @@ A viewer for Stats objects.
 import os
 
 from IPython.display import display
-from ipywidgets import interactive, IntSlider
+from ipywidgets import interactive, IntSlider, Dropdown
 import matplotlib.pyplot as plt
 import pandas as pd
 from pstats import Stats
@@ -74,12 +74,11 @@ class StatsViewer(object):
         "cumtime",
     ]
 
-    def __init__(self, filename, strip_dirs=True, remote_js=False):
+    def __init__(self, filename, strip_dirs=True):
         self.name = os.path.basename(filename)
         stats = Stats(filename)
         self.stats = stats.strip_dirs() if strip_dirs else stats
         self.timings, self.callers = _calc_frames(stats)
-        self.remote_js = remote_js
 
     def summary(self, count):
         fig = plt.figure()
@@ -122,7 +121,7 @@ class StatsViewer(object):
         plt.ylabel('Filename:Function Name')
 
     def _show_table(self, data):
-        return show_grid(data, remote_js=self.remote_js)
+        return show_grid(data)
 
     def table(self, fields=None):
         if fields is None:
@@ -147,7 +146,7 @@ class StatsViewer(object):
         return interactive(
             _interact,
             count=IntSlider(min=5, max=100, step=5, value=20),
-            sort_by=('cumtime', 'tottime', 'ncalls'),
+            sort_by=Dropdown(options=('cumtime', 'tottime', 'ncalls')),
         )
 
     def compare_chart(self, other, field='cumtime', count=35):
@@ -184,10 +183,10 @@ class StatsViewer(object):
             self.view(count, field, show_table=False)
 
         return display(
-            show_grid(self.timings, self.remote_js),
+            show_grid(self.timings),
             interactive(
                 _interact,
                 count=IntSlider(min=5, max=100, step=5, value=35),
-                field=('cumtime', 'tottime', 'ncalls'),
+                field=Dropdown(options=('cumtime', 'tottime', 'ncalls')),
             ),
         )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     install_requires=[
         'notebook',
-        'qgrid>=0.3.1',
+        'qgrid>=1.0.0',
         'seaborn',
     ],
     url="https://github.com/ssanderson/pstats-view"


### PR DESCRIPTION
Hello,

I tried to use pstatsview in a recent JupyterLab environment and it failed due to API changes in `qgrid` and `ipywidgets`. This PR fixes my problems, I hope it's useful!